### PR TITLE
[ENH] Add support for arbitrary estimator, compute only diagonal in time

### DIFF
--- a/meegnobis/metrics.py
+++ b/meegnobis/metrics.py
@@ -1,6 +1,6 @@
 """Module containing metrics"""
 import numpy as np
-from .rsa import _npairs, _get_unique_targets
+from .utils import _npairs, _get_unique_targets
 from scipy.spatial.distance import cdist
 
 

--- a/meegnobis/metrics.py
+++ b/meegnobis/metrics.py
@@ -1,0 +1,83 @@
+"""Module containing metrics"""
+import numpy as np
+from .rsa import _npairs, _get_unique_targets
+from scipy.spatial.distance import cdist
+
+
+class BaseMetric(object):
+    """A basic metric class"""
+    def __init__(self):
+        # whether the metric is symmetric or not
+        self._symmetric = False
+        # whether the metric is vectorized (i.e., doesn't need to be run
+        # separately for each target)
+        self._vectorized = False
+        # other values
+        self.data_train = None
+        self.targets_train = None
+
+    def fit(self, X, y):
+        raise NotImplementedError
+
+    def predict(self, X):
+        raise NotImplementedError
+
+    def score(self, X, y):
+        raise NotImplementedError
+
+    @property
+    def is_symmetric(self):
+        return self._symmetric
+
+    @property
+    def is_vectorized(self):
+        return self._vectorized
+
+
+class CDistMetric(BaseMetric):
+    def __init__(self, metric):
+        super(CDistMetric, self).__init__()
+        self._symmetric = True
+        self._vectorized = True
+        self._unique_targets_train = None
+        self._n_pairwise_targets_train = None
+        self.metric = lambda x, y: cdist(x, y, metric=metric)
+
+    def fit(self, X, y):
+        self.data_train = X
+        self.targets_train = y
+        self._unique_targets_train = _get_unique_targets(self.targets_train,
+                                                         self.targets_train)
+        self._n_pairwise_targets_train = _npairs(
+            len(self._unique_targets_train))
+
+    def predict(self, X):
+        if len(self._unique_targets_train) != X.shape[0]:
+            raise ValueError(
+                "Training set had {0} unique targets, and I am "
+                "expecting X to have the same number of "
+                "samples, but got {1}".format(len(self._unique_targets_train),
+                                              X.shape[0]))
+        dist = self.metric(self.data_train, X)
+        # make it symmetric
+        dist += dist.T
+        dist /= 2
+        return dist[np.triu_indices_from(dist)]
+
+    def score(self, X, y):
+        return self.predict(X)
+
+
+CDIST_METRICS_ = [
+    'cityblock',
+    'correlation',
+    'cosine',
+    'dice',
+    'euclidean',
+    'hamming',
+    'sqeuclidean'
+]
+
+CDIST_METRICS = {
+    metric: CDistMetric(metric=metric) for metric in CDIST_METRICS_
+}

--- a/meegnobis/rsa.py
+++ b/meegnobis/rsa.py
@@ -143,8 +143,7 @@ def _compute_fold(epoch, targets, train, test, metric_fx=_cdist,
     unique_targets = _get_unique_targets(targets_train, targets_test)
     targets_pairs = []
     for i_tr, tr_lbl in enumerate(unique_targets):
-        start_te = i_tr if metric_symmetric_time else 0
-        for _, te_lbl in enumerate(unique_targets[start_te:]):
+        for _, te_lbl in enumerate(unique_targets[i_tr:]):
             targets_pairs.append('+'.join(map(str, [tr_lbl, te_lbl])))
 
     return rdms, targets_pairs

--- a/meegnobis/rsa.py
+++ b/meegnobis/rsa.py
@@ -78,18 +78,22 @@ def _run_metric_binarytargets(metric_fx, data_train, targets_train, data_test,
         idx = 0
         for p1 in range(n_unique_targets):
             for p2 in range(p1, n_unique_targets):
-                target1 = unique_targets[p1]
-                target2 = unique_targets[p2]
-                mask_train = (targets_train == target1) | \
-                             (targets_train == target2)
-                mask_test = (targets_test == target1) | \
-                            (targets_test == target2)
-                # training
-                metric_fx.fit(data_train[mask_train],
-                              targets_train[mask_train])
-                # score
-                rdm[idx] = metric_fx.score(data_test[mask_test],
-                                           targets_test[mask_test])
+                if p1 == p2:
+                    # doesn't make sense to run classification with one label
+                    rdm[idx] = 1.
+                else:
+                    target1 = unique_targets[p1]
+                    target2 = unique_targets[p2]
+                    mask_train = (targets_train == target1) | \
+                                 (targets_train == target2)
+                    mask_test = (targets_test == target1) | \
+                                (targets_test == target2)
+                    # training
+                    metric_fx.fit(data_train[mask_train],
+                                  targets_train[mask_train])
+                    # score
+                    rdm[idx] = metric_fx.score(data_test[mask_test],
+                                               targets_test[mask_test])
                 idx += 1
     return rdm
 

--- a/meegnobis/rsa.py
+++ b/meegnobis/rsa.py
@@ -194,7 +194,7 @@ def _run_metric(epoch_train, epoch_test, targets_train, targets_test,
         n_times * (n_times - 1)/2 + n_times if metric_symmetric_time \
         else n_times * n_times
     # preallocate output
-    rdms = np.zeros((n_pairwise_targets, n_pairwise_times))
+    rdms = np.zeros((int(n_pairwise_targets), int(n_pairwise_times)))
     # compute pairwise metric
     idx = 0
     for t1 in range(n_times):

--- a/meegnobis/rsa.py
+++ b/meegnobis/rsa.py
@@ -115,11 +115,12 @@ def mean_group(array, targets):
         array containing the unique targets, corresponding to the order in
         avg_array
     """
-    unique_targets = np.unique(targets)
+    targets_ = np.array(targets)
+    unique_targets = np.unique(targets_)
     n_unique_targets = len(unique_targets)
     avg_array = np.zeros((n_unique_targets, array.shape[1], array.shape[2]))
     for i, t in enumerate(unique_targets):
-        mask = targets == t
+        mask = targets_ == t
         avg_array[i, ...] = array[mask, ...].mean(axis=0)
     return avg_array, unique_targets
 

--- a/meegnobis/rsa.py
+++ b/meegnobis/rsa.py
@@ -28,6 +28,16 @@ CDIST_METRICS = [
 OUR_METRICS = dict()
 
 
+def _npairs(n_items):
+    """Return the number of pairs given n_items; corresponds to the length
+    of a triu matrix (diagonal included)"""
+    if n_items < 2:
+        raise ValueError("More than two items required, "
+                         "passed {0}".format(n_items))
+    n_pairs = int(n_items * (n_items - 1) / 2. + n_items)
+    return n_pairs
+
+
 def _cdist(x, y, metric='correlation', targets_train=None, targets_test=None):
     """Computes correlation between x and y and fisher-transforms the output
 
@@ -59,8 +69,7 @@ def _linearsvm(data_train, data_test, targets_train, targets_test):
     # we need to loop through all pairwise targets
     unique_targets = _get_unique_targets(targets_train, targets_test)
     n_unique_targets = len(unique_targets)
-    n_pairwise_targets = n_unique_targets * (n_unique_targets - 1)/2 + \
-        n_unique_targets
+    n_pairwise_targets = _npairs(n_unique_targets)
     # preallocate output
     rdm = np.ones(n_pairwise_targets)
     idx = 0
@@ -83,6 +92,8 @@ def _linearsvm(data_train, data_test, targets_train, targets_test):
             rdm[idx] = svc.score(data_test[mask_test], targets_test[mask_test])
             idx += 1
     return rdm
+
+
 OUR_METRICS['linearsvm'] = _linearsvm
 
 
@@ -231,13 +242,11 @@ def _run_metric(epoch_train, epoch_test, targets_train, targets_test,
     times = range(n_times)
     unique_targets = _get_unique_targets(targets_train, targets_test)
     n_unique_targets = len(unique_targets)
-    n_pairwise_targets = n_unique_targets * (n_unique_targets - 1)/2 + \
-        n_unique_targets
-    n_pairwise_times = \
-        n_times * (n_times - 1)/2 + n_times if metric_symmetric_time \
+    n_pairwise_targets = _npairs(n_unique_targets)
+    n_pairwise_times = _npairs(n_times) if metric_symmetric_time \
         else n_times * n_times
     # preallocate output
-    rdms = np.zeros((int(n_pairwise_targets), int(n_pairwise_times)))
+    rdms = np.zeros((n_pairwise_targets, n_pairwise_times))
     # compute pairwise metric
     idx = 0
     for t1 in range(n_times):

--- a/meegnobis/tests/test_metrics.py
+++ b/meegnobis/tests/test_metrics.py
@@ -1,0 +1,50 @@
+"""Testing metrics"""
+from ..metrics import CDIST_METRICS
+from ..testing import generate_epoch
+from scipy.spatial.distance import cdist
+import numpy as np
+import pytest
+from numpy.testing import assert_array_equal, assert_equal
+
+
+@pytest.mark.parametrize('metric_name', CDIST_METRICS.keys())
+def test_cdist_metrics_(metric_name):
+    epoch = generate_epoch()
+    data = epoch.get_data()
+    metric = CDIST_METRICS[metric_name]
+    fake_targets = np.arange(data.shape[0])
+
+    # smoke test
+    metric.fit(data[..., 0], fake_targets)
+    metric.score(data[..., 0], fake_targets)
+
+    # check it complains if we try to fit something with a different number
+    # of targets
+    targets = epoch.events[:, -1]
+    assert(len(np.unique(targets)) == 2)
+    assert(2 != data.shape[0])
+    metric.fit(data[..., 0], targets)
+    with pytest.raises(ValueError):
+        metric.score(data[..., 0], targets)
+
+    # now test we get the actual values
+    epoch_train = generate_epoch(n_epochs_cond=1, n_times=1, n_conditions=10)
+    data_train = epoch_train.get_data()
+    targets_train = epoch_train.events[:, -1]
+    epoch_test = generate_epoch(n_epochs_cond=1, n_times=1, n_conditions=10)
+    data_test = epoch_test.get_data()
+    targets_test = epoch_test.events[:, -1]
+    # just to be sure
+    assert_array_equal(targets_train, targets_test)
+    # fit/score
+    metric.fit(data_train[:, 0], targets_train)
+    out = metric.score(data_test[:, 0], targets_test)
+    # we should get a vector
+    assert(out.ndim == 1)
+    out_cdist = cdist(data_train[:, 0], data_test[:, 0],
+                      metric=metric_name)
+    out_cdist += out_cdist.T
+    out_cdist /= 2
+    out_cdist = out_cdist[np.triu_indices_from(out_cdist)]
+    assert_array_equal(out, out_cdist)
+

--- a/meegnobis/tests/test_rsa.py
+++ b/meegnobis/tests/test_rsa.py
@@ -124,7 +124,10 @@ def test_compute_fold_values():
 @pytest.mark.parametrize("cv_normalize_noise", (None, 'epoch', 'baseline'))
 @pytest.mark.parametrize("n_splits", (4, 10))
 @pytest.mark.parametrize("batch_size", (2, 5))
-def test_compute_temporal_rdm(cv_normalize_noise, n_splits, batch_size):
+@pytest.mark.parametrize("metric_symmetric_time", (True, False))
+def test_compute_temporal_rdm(cv_normalize_noise, n_splits, batch_size,
+                              metric_symmetric_time):
+    """Mostly a smoke test for combinations of parameters"""
     n_epochs_cond = 20
     n_conditions = 4
     epoch = generate_epoch(n_epochs_cond=n_epochs_cond,
@@ -134,12 +137,15 @@ def test_compute_temporal_rdm(cv_normalize_noise, n_splits, batch_size):
     rdm, target_pairs = compute_temporal_rdm(
         epoch, cv=cv, targets=epoch.events[:, 2],
         cv_normalize_noise=cv_normalize_noise,
-        batch_size=batch_size)
+        batch_size=batch_size, metric_symmetric_time=metric_symmetric_time)
     n_times = len(epoch.times)
     n_pairwise_conditions = n_conditions * (n_conditions - 1)/2 + n_conditions
     n_pairwise_times = n_times * (n_times - 1)/2 + n_times
-    assert(rdm.shape == (n_pairwise_conditions, n_pairwise_times))
-    assert(rdm.shape[0] == len(target_pairs))
+    assert_equal(rdm.shape[0], len(target_pairs))
+    if metric_symmetric_time:
+        assert_equal(rdm.shape, (n_pairwise_conditions, n_pairwise_times))
+    else:
+        assert_equal(rdm.shape, (n_pairwise_conditions, n_times*n_times))
 
 
 def test_compute_temporal_rdm_batch_size():

--- a/meegnobis/tests/test_rsa.py
+++ b/meegnobis/tests/test_rsa.py
@@ -139,7 +139,9 @@ def test_compute_fold_values():
 @pytest.mark.parametrize("cv_normalize_noise", (None, 'epoch', 'baseline'))
 @pytest.mark.parametrize("n_splits", (4, 10))
 @pytest.mark.parametrize("batch_size", (2, 5))
-def test_compute_temporal_rdm(cv_normalize_noise, n_splits, batch_size):
+@pytest.mark.parametrize("time_diag_only", (True, False))
+def test_compute_temporal_rdm(cv_normalize_noise, n_splits, batch_size,
+                              time_diag_only):
     """Mostly a smoke test for combinations of parameters"""
     n_epochs_cond = 20
     n_conditions = 4
@@ -150,10 +152,11 @@ def test_compute_temporal_rdm(cv_normalize_noise, n_splits, batch_size):
     rdm, target_pairs = compute_temporal_rdm(
         epoch, cv=cv, targets=epoch.events[:, 2],
         cv_normalize_noise=cv_normalize_noise,
-        batch_size=batch_size, mean_groups=True)
+        batch_size=batch_size, mean_groups=True,
+        time_diag_only=time_diag_only)
     n_times = len(epoch.times)
     n_pairwise_conditions = _npairs(n_conditions)
-    n_pairwise_times = _npairs(n_times)
+    n_pairwise_times = n_times if time_diag_only else _npairs(n_times)
     assert_equal(rdm.shape[0], len(target_pairs))
     assert_equal(rdm.shape, (n_pairwise_conditions, n_pairwise_times))
 

--- a/meegnobis/tests/test_rsa.py
+++ b/meegnobis/tests/test_rsa.py
@@ -61,7 +61,8 @@ def test_compute_fold(cv_normalize_noise):
 
     metric_fx = CDIST_METRICS['correlation']
     rdms, target_pairs = _compute_fold(metric_fx, targets, train, test, epoch,
-                                       cv_normalize_noise=cv_normalize_noise)
+                                       cv_normalize_noise=cv_normalize_noise,
+                                       mean_groups=True)
     n_times = len(epoch.times)
     n_pairwise_conditions = _npairs(n_conditions)
     n_pairwise_times = _npairs(n_times)
@@ -82,7 +83,8 @@ def test_compute_fold(cv_normalize_noise):
     targets = map(str, targets)
     with pytest.raises(ValueError):
         rdms = _compute_fold(metric_fx, targets, train, test, epoch,
-                             cv_normalize_noise=cv_normalize_noise)
+                             cv_normalize_noise=cv_normalize_noise,
+                             mean_groups=True)
 
 
 def test_compute_fold_valuerrorcov():
@@ -148,7 +150,7 @@ def test_compute_temporal_rdm(cv_normalize_noise, n_splits, batch_size):
     rdm, target_pairs = compute_temporal_rdm(
         epoch, cv=cv, targets=epoch.events[:, 2],
         cv_normalize_noise=cv_normalize_noise,
-        batch_size=batch_size)
+        batch_size=batch_size, mean_groups=True)
     n_times = len(epoch.times)
     n_pairwise_conditions = _npairs(n_conditions)
     n_pairwise_times = _npairs(n_times)
@@ -168,11 +170,11 @@ def test_compute_temporal_rdm_batch_size():
     # one batch
     rdm1, target_pairs1 = compute_temporal_rdm(
         epoch, cv=cv, targets=epoch.events[:, 2],
-        batch_size=20)
+        batch_size=20, mean_groups=True)
     # two batches
     rdm2, target_pairs2 = compute_temporal_rdm(
         epoch, cv=cv, targets=epoch.events[:, 2],
-        batch_size=5)
+        batch_size=5, mean_groups=True)
     assert_array_almost_equal(rdm1, rdm2)
     assert_array_equal(target_pairs1, target_pairs2)
 

--- a/meegnobis/tests/test_rsa.py
+++ b/meegnobis/tests/test_rsa.py
@@ -44,6 +44,12 @@ def test_mean_group():
     assert_array_equal(avg_array, np.asanyarray([array[:5].mean(axis=0),
                                                  array[5:].mean(axis=0)]))
 
+    # check it works even it targets is a list
+    avg_array, unique_targets = mean_group(array, targets.tolist())
+    assert_array_equal(unique_targets, [0, 1])
+    assert_array_equal(avg_array, np.asanyarray([array[:5].mean(axis=0),
+                                                 array[5:].mean(axis=0)]))
+
 
 @pytest.mark.parametrize("cv_normalize_noise", [None, 'epoch', 'baseline'])
 def test_compute_fold(cv_normalize_noise):

--- a/meegnobis/tests/test_utils.py
+++ b/meegnobis/tests/test_utils.py
@@ -4,6 +4,8 @@ import pytest
 
 from mne import create_info, EpochsArray
 from numpy.testing import assert_array_equal, assert_equal
+
+from meegnobis.utils import _npairs
 from ..utils import convolve, moving_average
 from ..testing import generate_epoch
 
@@ -85,3 +87,9 @@ def test_moving_average():
                            convolve(array_3d, filt))
 
 
+def test_npairs():
+    for nitems in [100, 101]:
+        assert(int(nitems * (nitems-1)/2. + nitems) == _npairs(nitems))
+        assert(isinstance(_npairs(nitems), int))
+    with pytest.raises(ValueError):
+        _npairs(1)

--- a/meegnobis/utils.py
+++ b/meegnobis/utils.py
@@ -79,4 +79,22 @@ def moving_average(epoch, twindow):
     data = convolve(data, filt)
     data = np.transpose(data, [1, 0, 2])
     epoch_._data = data
-    return(epoch_)
+    return epoch_
+
+
+def _npairs(n_items):
+    """Return the number of pairs given n_items; corresponds to the length
+    of a triu matrix (diagonal included)"""
+    if n_items < 2:
+        raise ValueError("More than two items required, "
+                         "passed {0}".format(n_items))
+    n_pairs = int(n_items * (n_items - 1) / 2. + n_items)
+    return n_pairs
+
+
+def _get_unique_targets(targets_train, targets_test):
+    unique_targets_train = np.unique(targets_train)
+    unique_targets_test = np.unique(targets_test)
+    unique_targets = sorted(set(unique_targets_train).
+                            intersection(unique_targets_test))
+    return unique_targets


### PR DESCRIPTION
- Refactored code to allow an arbitrary estimator with `fit/score` attributes (e.g. sklearn estimators)
- Add option to compute the RDM only for the diagonal in time, that is `training_time == testing_time`